### PR TITLE
CrateIO doesn't exist anymore as PyPi mirror

### DIFF
--- a/src/pypi.php
+++ b/src/pypi.php
@@ -29,7 +29,7 @@ if (strlen($query) >= $min_query_length) {
 		$downloads = strip_tags($matches[1][1]);
 		$details = strip_tags($matches[1][2]);
 		
-		$w->result( $title, 'https://crate.io'.$url, $title."    ".$downloads, $details, 'icon-cache/pypi.png' );
+		$w->result( $title, 'https://pypi.python.org'.$url, $title."    ".$downloads, $details, 'icon-cache/pypi.png' );
 		if (!--$count) { break; }
 	}
 	


### PR DESCRIPTION
While searching on PyPi worked fine, actually visiting the package page was broken because Crate.io [has been discontinued](https://caremad.io/blog/crate-io-new-ownership/). I fixed the url to lookup the package, back to the PyPi website.
