### PR TITLE
Fix typo in case of class `Cache`

### DIFF
--- a/v2/cache.php
+++ b/v2/cache.php
@@ -4,7 +4,7 @@ ini_set('memory_limit', '-1'); // required for raspbian - remove later
 
 require_once('workflows.php');
 
-class cache {
+class Cache {
 	var $cache_age = 14;
 	var $dbs = array(
 		"alcatraz" => "https://raw.githubusercontent.com/mneorr/alcatraz-packages/master/packages.json",


### PR DESCRIPTION
Seems to not have caused any pain yet, but PHP can be odd sometimes, 
and it’s loaded everywhere as `new Cache();` so best to stick to that.
