### PR TITLE
Fix docker results not working since 3.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Package Managers ([Download v3.06](https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.06/Package.Managers.alfredworkflow))
+# Package Managers ([Download v3.07](https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.07/Package.Managers.alfredworkflow))
 
 Package Repo Search
 

--- a/current-version.json
+++ b/current-version.json
@@ -1,5 +1,5 @@
 {
-	"version": 3.06,
-	"download_url": "https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.04/Package.Managers.alfredworkflow",
+	"version": 3.07,
+	"download_url": "https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.07/Package.Managers.alfredworkflow",
 	"description": "Package Repo Search"
 }

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -52,5 +52,5 @@ class Docker extends Repo
 }
 
 // Test code, uncomment to debug this script from the command-line
- $repo = new Docker();
- echo $repo->search('ng');
+// $repo = new Docker();
+// echo $repo->search('ng');


### PR DESCRIPTION
Due to [this change](https://github.com/willfarrell/alfred-pkgman-workflow/commit/89a29f9fdcdb4717a3822038b18427556294a68c#diff-a290c4b0162ec590534089ccf35c5966) in `src/Docker.php`.

Tested this and works as expected now.