### PR TITLE
Fix maven url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Package Managers ([Download v3.08](https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.08/Package.Managers.alfredworkflow))
+# Package Managers ([Download v3.09](https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.09/Package.Managers.alfredworkflow))
 
 Package Repo Search
 

--- a/current-version.json
+++ b/current-version.json
@@ -1,5 +1,5 @@
 {
-	"version": 3.08,
-	"download_url": "https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.08/Package.Managers.alfredworkflow",
+	"version": 3.09,
+	"download_url": "https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.09/Package.Managers.alfredworkflow",
 	"description": "Package Repo Search"
 }

--- a/src/Gradle.php
+++ b/src/Gradle.php
@@ -9,7 +9,7 @@ class Gradle extends Repo
 	protected $id         = 'gradle';
 	protected $kind       = 'libraries';
 	protected $url        = 'http://search.maven.org';
-	protected $search_url = 'http://search.maven.org/#search|ga|1|';
+	protected $search_url = 'http://search.maven.org/#search%7Cga%7C1%7C';
 
 	public function search($query)
 	{
@@ -27,7 +27,7 @@ class Gradle extends Repo
 			
 			// make params
 			$title = "{$pkg->a} (v{$pkg->latestVersion})";
-			$url = "{$this->url}/#artifactdetails|{$pkg->g}|{$pkg->a}|{$pkg->latestVersion}|{$pkg->p}";
+			$url = "{$this->url}/#artifactdetails%7C{$pkg->g}%7C{$pkg->a}%7C{$pkg->latestVersion}%7C{$pkg->p}";
 			$details = "GroupId: {$pkg->id}";
 	
 			$this->cache->w->result(

--- a/src/Maven.php
+++ b/src/Maven.php
@@ -9,7 +9,7 @@ class Maven extends Repo
 	protected $id         = 'maven';
 	protected $kind       = 'libraries';
 	protected $url        = 'http://search.maven.org';
-	protected $search_url = 'http://search.maven.org/#search|ga|1|';
+	protected $search_url = 'http://search.maven.org/#search%7Cga%7C1%7C';
 
 	public function search($query)
 	{
@@ -27,7 +27,7 @@ class Maven extends Repo
 			
 			// make params
 			$title = "{$pkg->a} (v{$pkg->latestVersion})";
-			$url = "{$this->url}/#artifactdetails|{$pkg->g}|{$pkg->a}|{$pkg->latestVersion}|{$pkg->p}";
+			$url = "{$this->url}/#artifactdetails%7C{$pkg->g}%7C{$pkg->a}%7C{$pkg->latestVersion}%7C{$pkg->p}";
 			$details = "GroupId: {$pkg->id}";
 	
 			$this->cache->w->result(

--- a/src/update.json
+++ b/src/update.json
@@ -1,4 +1,5 @@
 {
-	"version": 3.08,
-	"remote_json": "https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.08/Package.Managers.alfredworkflow"
+	"version": 3.09,
+	"remote_json": "https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.09/Package.Managers.alfredworkflow"
 }
+


### PR DESCRIPTION
Hi,

I come across a problem that opening a maven/gradle module page from pkgman will always leave me a corrupted url `http://search.maven.org/#artifactdetails` in browser. 

You can reproduce this issue in 3 steps:

1. input `maven guava` in Alfred
2. select any module from result, then press enter
3. browser is launched but not it's showing the module's page (at least in my case)

Finally I found the reason is that url is split by '|' (assuming no '|' should appears in url but it's not true for maven's page), then I fix it by encoding '|' to '%7c'.

Quote from my commit message:
> A typical url to a package from maven central repository should be like
> http://search.maven.org/#artifactdetails|{groupId}|{artifactId}|{ver}|{pkg},
> but the actual url be opened in browser is cutted from pipeline by a cut command
> `url=$(echo $query | cut -d "|" -f2)`, which will accidently cut maven's
> url into pieces.
