### PR TITLE
Update npm search engine to npms.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Package Managers ([Download v3.13](https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.13/Package.Managers.alfredworkflow))
+# Package Managers ([Download v3.14](https://github.com/willfarrell/alfred-pkgman-workflow/releases/download/3.14/Package.Managers.alfredworkflow))
 
 Package Repo Search
 

--- a/src/Npm.php
+++ b/src/Npm.php
@@ -7,46 +7,30 @@ require_once('Repo.php');
 class Npm extends Repo
 {
 	protected $id         = 'npm';
-	protected $url        = 'https://www.npmjs.com';
-	protected $search_url = 'https://www.npmjs.com/search?q=';
-
-	public function search($query)
-	{
-		if (!$this->hasMinQueryLength($query)) {
+	protected $url        = 'https://npms.io';
+	protected $search_url = 'https://api.npms.io/v2/search?q=';
+  
+  public function search($query)
+  {
+    if (!$this->hasMinQueryLength($query)) {
 			return $this->xml(); 
 		}
-		
-		$this->pkgs = $this->cache->get_query_regex(
+    
+    $this->pkgs = $this->cache->get_query_json(
 			$this->id,
 			$query,
-			"{$this->search_url}{$query}",
-			'/<div class="package-details">([\s\S]*?)<\/div>/i'
+			"{$this->search_url}{$query}&size={$this->max_return}"
 		);
-		
-		foreach($this->pkgs as $pkg) {
+    
+    foreach($this->pkgs->results as $pkg) {
+      $p = $pkg->package;
+			$name = $p->name;
 			
-			// make params
-			preg_match('/<a class="name" href="[\s\S]*?">([\s\S]*?)<\/a>/i', $pkg, $matches);
-			$title = trim(strip_tags($matches[1]));
-
-            //preg_match('/<a class="author" href="[\s\S]*?">([\s\S]*?)<\/a>/i', $pkg, $matches);
-			//$author = trim(strip_tags($matches[1]));
-		
-			preg_match('/<p class="description">([\s\S]*?)<\/p>/i', $pkg, $matches);
-		
-			$description = html_entity_decode(trim(strip_tags($matches[1])));
-			
-			//preg_match('/<span class="stars"><i class="icon-star"></i>([\s\S]*?)<\/span>/i', $pkg, $matches);
-            //$stars = trim(strip_tags($matches[1]));
-
-			preg_match('/<span class="version">([\s\S]*?)<\/span>/i', $pkg, $matches);
-			$version = trim(strip_tags($matches[1]));
-	
 			$this->cache->w->result(
-				$title,
-				$this->makeArg($title, "{$this->url}/package/{$title}"),
-				"{$title} ~ {$version}", //.' by '.$author,
-				$description,
+				$this->id,
+				$this->makeArg($name, $p->links->npm, "{$p->name}: {$p->version}"),
+				$name,
+				$p->description,
 				"icon-cache/{$this->id}.png"
 			);
 			
@@ -55,12 +39,11 @@ class Npm extends Repo
 				break;
 			}
 		}
-		
-		
+
 		$this->noResults($query, "{$this->search_url}{$query}");
 
 		return $this->xml();
-	}
+  }
 }
 
 // Test code, uncomment to debug this script from the command-line


### PR DESCRIPTION
At some point, markup on npmjs.com changed, breaking the existing code
in `Npm.php`. This commit fixes that problem by implementing the change
proposed in #94:

> Update npm with new search engine
>
> `https://npms.io/search?term={query}`

This commit also:

- updates `Package Managers.alfredworkflow` with latest version
- updates the `README.md`, bumping version number to 3.14

Resolves #94.