### PR TITLE
Yarn: Handle spaces in package query

### DIFF
--- a/src/Yarn.php
+++ b/src/Yarn.php
@@ -13,6 +13,7 @@ class Yarn extends Repo
 
   public function search($query)
   {
+    $query = str_replace(' ', '+', $query);
     if (!$this->hasMinQueryLength($query)) {
       return $this->xml();
     }


### PR DESCRIPTION
Spaces in query are replaced by a plus operator. 
This addresses issue #111.