### PR TITLE
Npm: Handle spaces in package query

### DIFF
--- a/src/Npm.php
+++ b/src/Npm.php
@@ -12,6 +12,7 @@ class Npm extends Repo
 
 	public function search($query)
 	{
+		$query = str_replace(' ', '+', $query);
 		if (!$this->hasMinQueryLength($query)) {
 			return $this->xml(); 
 		}


### PR DESCRIPTION
Spaces in query are replaced by a plus operator. 
This addresses issue #111.