### PR TITLE
Set a default user agent to indicate that Alfred is making the request

### DIFF
--- a/src/Hex.php
+++ b/src/Hex.php
@@ -9,7 +9,7 @@ class Hex extends Repo
     protected $id         = 'hex';
     protected $kind       = 'components';
     protected $url        = 'https://hex.pm';
-    protected $search_url = 'https://hex.pm/api/packages?search=';
+    protected $search_url = 'https://hex.pm/api/packages?sort=downloads&search=';
 
     public function search($query)
     {

--- a/src/Workflows.php
+++ b/src/Workflows.php
@@ -344,7 +344,8 @@ class Workflows {
 		$defaults = array(                                  // Create a list of default curl options
 			CURLOPT_RETURNTRANSFER => true,                 // Returns the result as a string
 			CURLOPT_URL => $url,                            // Sets the url to request
-			CURLOPT_FRESH_CONNECT => true
+			CURLOPT_FRESH_CONNECT => true,
+			CURLOPT_USERAGENT => 'AlfredPkgMan-Workflow'
 		);
 
 		if ( $options ):


### PR DESCRIPTION
This fixes https://github.com/willfarrell/alfred-pkgman-workflow/issues/123 which requires that
a user agent is present when accessing Hex.