### PR TITLE
feat: handle deprecated definitelytyped packages

### DIFF
--- a/src/DefinitelyTyped.php
+++ b/src/DefinitelyTyped.php
@@ -5,7 +5,8 @@ class DefinitelyTyped extends Repo
 {
     protected $id         = 'dt';
     protected $url        = 'https://definitelytyped.org';
-    protected $search_url = 'https://api.npms.io/v2/search?q=scope:types+';
+    protected $search_url = 'https://api.npms.io/v2/search';
+    protected $npm_scope  = 'types';
 
     public function search($query)
     {
@@ -16,18 +17,22 @@ class DefinitelyTyped extends Repo
         $this->pkgs = $this->cache->get_query_json(
             $this->id,
             $query,
-            "{$this->search_url}{$query}&size={$this->max_return}"
+            "{$this->search_url}?q=scope:{$this->npm_scope}+{$query}&size={$this->max_return}"
         );
 
         foreach ($this->pkgs->results as $pkg) {
             $p = $pkg->package;
-            $name = $p->name;
+            $scope_prefix = "@{$this->npm_scope}/";
+            $is_deprecated = !empty($pkg->flags->deprecated);
+            $name = $is_deprecated ? str_replace($scope_prefix, "", $p->name) : $p->name;
+            $description = $is_deprecated ? "[!] {$p->name} has been deprecated: {$pkg->flags->deprecated}" : $p->description;
+            $link = $is_deprecated ? str_replace(urlencode($scope_prefix), "", $p->links->npm) : $p->links->npm;
 
             $this->cache->w->result(
                 $this->id,
-                $this->makeArg($name, $p->links->npm, "{$p->name}: {$p->version}"),
+                $this->makeArg($name, $link, "{$p->name}: {$p->version}"),
                 $name,
-                $p->description,
+                $description,
                 "icon-cache/{$this->id}.png"
             );
 


### PR DESCRIPTION
Provides more convenient search results for deprecated DefinitelyTyped packages:

* Fallback to npm package with bundled typings when DefinitelyTyped package is deprecated
* Display deprecation notice as description