### PR TITLE
Fix a typo in info.plist

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1655,7 +1655,7 @@ open $url</string>
 				<key>queuemode</key>
 				<integer>1</integer>
 				<key>runningsubtext</key>
-				<string>Searcing for "{query}"</string>
+				<string>Searching for "{query}"</string>
 				<key>script</key>
 				<string>php ./bin/index.php brew {query}</string>
 				<key>scriptargtype</key>


### PR DESCRIPTION
## Why

This is a simple typo fix, so I didn't do any of the below

## Checklist

- [ ] Cloned the repository, set `$ALFRED_PKGMAN_WORKFLOW_DIR`, and ran `make` to use your cloned code as the active Workflow in Alfred
- [ ] Optionally, include a large icon in the `src/icon-src/` folder that is square.
- [ ] Optionally, include a cached icon in the `src/icon-cache/` folder, sized to 256x256 pixels. Alfred creates these when you insert an image into a workflow. You can get this from inside the `.alfredworkflow`. Right-click the workflow in Alfred, click `Show in Finder`. The `--hash-value--.png` file will be in that folder. Copy to `src/icon-cache` and rename.
- [ ] Optionally, add a screenshot. Use ⌘ (command) + ⇧ (shift) + 4, press ␣ (space), then click on the Alfred window to create a clean screen shot. Place in the `screenshots` folder
- [ ] Update README.md with any necessary or changed documentation, and any new screenshots.
- [ ] Increment the version number of the workflow following (Semantic Versioning)[https://semver.org]
- [ ] Run `make release` to package up your changes & copy the Workflow & its `info.plist` to the root of the repository, and commit those two changes on their own, e.g., `Bump to 5.1.1`
